### PR TITLE
Add basic Go + React chess app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# chatgptcodex
+# ChatGPT Codex Chess App
+
+This repository contains a minimal chess application with a Go backend and a React frontend.
+
+## Backend
+
+The Go server lives in the `server` directory. It exposes two endpoints:
+
+- `GET /board` – returns the current board state as an array of strings.
+- `POST /move` – accepts JSON `{"from": "e2", "to": "e4"}` to move a piece.
+
+The server does not validate chess rules; it simply moves pieces on the board.
+
+Run the backend:
+
+```bash
+cd server
+go run .
+```
+
+This starts the server on port `8080`.
+
+## Frontend
+
+The frontend is a very small React app in the `client` directory. Open `index.html` in a browser after starting the backend. The board is displayed and you can select a piece then a target square to move it.
+
+No build step is required because React is loaded from a CDN.
+

--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,43 @@
+const e = React.createElement;
+
+function Board() {
+  const [board, setBoard] = React.useState([]);
+  const [selection, setSelection] = React.useState(null);
+
+  const fetchBoard = () => {
+    fetch('http://localhost:8080/board')
+      .then(res => res.json())
+      .then(setBoard);
+  };
+
+  React.useEffect(fetchBoard, []);
+
+  const handleClick = (row, col) => {
+    if (!selection) {
+      setSelection({ row, col });
+      return;
+    }
+    const from = String.fromCharCode('a'.charCodeAt(0) + selection.col) + (8 - selection.row);
+    const to = String.fromCharCode('a'.charCodeAt(0) + col) + (8 - row);
+    fetch('http://localhost:8080/move', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from, to })
+    }).then(fetchBoard);
+    setSelection(null);
+  };
+
+  return e('div', { className: 'board' },
+    board.map((row, r) =>
+      row.split('').map((cell, c) =>
+        e('div', {
+          key: r + '-' + c,
+          className: 'cell ' + ((r + c) % 2 === 0 ? 'white' : 'black'),
+          onClick: () => handleClick(r, c)
+        }, cell === '.' ? '' : cell)
+      )
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(e(Board));

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <title>Chess App</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .board { display: grid; grid-template-columns: repeat(8, 50px); width: 400px; }
+        .cell { width: 50px; height: 50px; display: flex; align-items: center; justify-content: center; font-size: 32px; }
+        .white { background-color: #eee; }
+        .black { background-color: #666; color: white; }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,0 +1,3 @@
+module chessapp
+
+go 1.23.8

--- a/server/main.go
+++ b/server/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+)
+
+type Board struct {
+	mu   sync.Mutex
+	grid [8][8]rune
+}
+
+func NewBoard() *Board {
+	b := &Board{}
+	setup := []string{
+		"rnbqkbnr",
+		"pppppppp",
+		"........",
+		"........",
+		"........",
+		"........",
+		"PPPPPPPP",
+		"RNBQKBNR",
+	}
+	for i := 0; i < 8; i++ {
+		for j := 0; j < 8; j++ {
+			b.grid[i][j] = rune(setup[i][j])
+		}
+	}
+	return b
+}
+
+// square converts notation like e2 to array indices
+func square(pos string) (int, int, bool) {
+	if len(pos) != 2 {
+		return 0, 0, false
+	}
+	file := int(pos[0] - 'a')
+	rank := int('8' - pos[1])
+	if file < 0 || file > 7 || rank < 0 || rank > 7 {
+		return 0, 0, false
+	}
+	return rank, file, true
+}
+
+func (b *Board) Move(from, to string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	fr, fc, ok1 := square(from)
+	tr, tc, ok2 := square(to)
+	if !ok1 || !ok2 {
+		return false
+	}
+	piece := b.grid[fr][fc]
+	if piece == '.' {
+		return false
+	}
+	b.grid[tr][tc] = piece
+	b.grid[fr][fc] = '.'
+	return true
+}
+
+func (b *Board) State() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	rows := make([]string, 8)
+	for i := 0; i < 8; i++ {
+		row := make([]rune, 8)
+		for j := 0; j < 8; j++ {
+			row[j] = b.grid[i][j]
+		}
+		rows[i] = string(row)
+	}
+	return rows
+}
+
+func main() {
+	board := NewBoard()
+
+	http.HandleFunc("/board", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		json.NewEncoder(w).Encode(board.State())
+	})
+
+	http.HandleFunc("/move", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		if r.Method == http.MethodOptions {
+			w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			return
+		}
+		var req struct {
+			From string `json:"from"`
+			To   string `json:"to"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if board.Move(req.From, req.To) {
+			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		} else {
+			json.NewEncoder(w).Encode(map[string]string{"status": "invalid"})
+		}
+	})
+
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
## Summary
- create a Go backend with `/board` and `/move` endpoints
- add a simple React frontend loaded via CDN
- update README with instructions

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_68528174243083328aec2f0214e73d19