### PR TITLE
Add drag-and-drop chess board with legal move validation

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -2,42 +2,77 @@ const e = React.createElement;
 
 function Board() {
   const [board, setBoard] = React.useState([]);
-  const [selection, setSelection] = React.useState(null);
+  const [dragFrom, setDragFrom] = React.useState(null);
+
+  const pieceIcons = {
+    K: "\u2654",
+    Q: "\u2655",
+    R: "\u2656",
+    B: "\u2657",
+    N: "\u2658",
+    P: "\u2659",
+    k: "\u265A",
+    q: "\u265B",
+    r: "\u265C",
+    b: "\u265D",
+    n: "\u265E",
+    p: "\u265F",
+  };
 
   const fetchBoard = () => {
-    fetch('http://localhost:8080/board')
-      .then(res => res.json())
+    fetch("http://localhost:8080/board")
+      .then((res) => res.json())
       .then(setBoard);
   };
 
   React.useEffect(fetchBoard, []);
 
-  const handleClick = (row, col) => {
-    if (!selection) {
-      setSelection({ row, col });
-      return;
-    }
-    const from = String.fromCharCode('a'.charCodeAt(0) + selection.col) + (8 - selection.row);
-    const to = String.fromCharCode('a'.charCodeAt(0) + col) + (8 - row);
-    fetch('http://localhost:8080/move', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ from, to })
-    }).then(fetchBoard);
-    setSelection(null);
+  const onDragStart = (r, c) => () => {
+    setDragFrom({ r, c });
   };
 
-  return e('div', { className: 'board' },
+  const onDrop = (r, c) => () => {
+    if (!dragFrom) return;
+    const from =
+      String.fromCharCode("a".charCodeAt(0) + dragFrom.c) + (8 - dragFrom.r);
+    const to = String.fromCharCode("a".charCodeAt(0) + c) + (8 - r);
+    fetch("http://localhost:8080/move", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ from, to }),
+    }).then(fetchBoard);
+    setDragFrom(null);
+  };
+
+  const allowDrop = (e) => e.preventDefault();
+
+  return e(
+    "div",
+    { className: "board" },
     board.map((row, r) =>
-      row.split('').map((cell, c) =>
-        e('div', {
-          key: r + '-' + c,
-          className: 'cell ' + ((r + c) % 2 === 0 ? 'white' : 'black'),
-          onClick: () => handleClick(r, c)
-        }, cell === '.' ? '' : cell)
-      )
-    )
+      row.split("").map((cell, c) =>
+        e(
+          "div",
+          {
+            key: r + "-" + c,
+            className: "cell " + ((r + c) % 2 === 0 ? "white" : "black"),
+            onDragOver: allowDrop,
+            onDrop: onDrop(r, c),
+          },
+          cell === "."
+            ? ""
+            : e(
+                "span",
+                {
+                  draggable: true,
+                  onDragStart: onDragStart(r, c),
+                },
+                pieceIcons[cell] || cell,
+              ),
+        ),
+      ),
+    ),
   );
 }
 
-ReactDOM.createRoot(document.getElementById('root')).render(e(Board));
+ReactDOM.createRoot(document.getElementById("root")).render(e(Board));

--- a/client/index.html
+++ b/client/index.html
@@ -1,20 +1,47 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
+  <head>
     <meta charset="UTF-8" />
     <title>Chess App</title>
     <style>
-        body { font-family: Arial, sans-serif; }
-        .board { display: grid; grid-template-columns: repeat(8, 50px); width: 400px; }
-        .cell { width: 50px; height: 50px; display: flex; align-items: center; justify-content: center; font-size: 32px; }
-        .white { background-color: #eee; }
-        .black { background-color: #666; color: white; }
+      body {
+        font-family: Arial, sans-serif;
+      }
+      .board {
+        display: grid;
+        grid-template-columns: repeat(8, 50px);
+        width: 400px;
+      }
+      .cell {
+        width: 50px;
+        height: 50px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 32px;
+      }
+      .cell span {
+        cursor: grab;
+      }
+      .white {
+        background-color: #eee;
+      }
+      .black {
+        background-color: #666;
+        color: white;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
     <div id="root"></div>
-    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script
+      src="https://unpkg.com/react@18/umd/react.development.js"
+      crossorigin
+    ></script>
+    <script
+      src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"
+      crossorigin
+    ></script>
     <script src="app.js"></script>
-</body>
+  </body>
 </html>

--- a/server/main.go
+++ b/server/main.go
@@ -44,6 +44,110 @@ func square(pos string) (int, int, bool) {
 	return rank, file, true
 }
 
+func color(piece rune) int {
+	if piece >= 'A' && piece <= 'Z' {
+		return 1 // white
+	}
+	if piece >= 'a' && piece <= 'z' {
+		return -1 // black
+	}
+	return 0
+}
+
+func sign(x int) int {
+	switch {
+	case x > 0:
+		return 1
+	case x < 0:
+		return -1
+	}
+	return 0
+}
+
+func (b *Board) clearPath(fr, fc, tr, tc int) bool {
+	dr := sign(tr - fr)
+	dc := sign(tc - fc)
+	r, c := fr+dr, fc+dc
+	for r != tr || c != tc {
+		if b.grid[r][c] != '.' {
+			return false
+		}
+		r += dr
+		c += dc
+	}
+	return true
+}
+
+func (b *Board) validMove(fr, fc, tr, tc int, piece rune) bool {
+	if fr == tr && fc == tc {
+		return false
+	}
+	dest := b.grid[tr][tc]
+	if dest != '.' && color(dest) == color(piece) {
+		return false
+	}
+
+	dr := tr - fr
+	dc := tc - fc
+
+	switch piece {
+	case 'P':
+		if dr == -1 && dc == 0 && dest == '.' {
+			return true
+		}
+		if fr == 6 && dr == -2 && dc == 0 && dest == '.' && b.grid[fr-1][fc] == '.' {
+			return true
+		}
+		if dr == -1 && (dc == -1 || dc == 1) && dest != '.' && color(dest) == -1 {
+			return true
+		}
+	case 'p':
+		if dr == 1 && dc == 0 && dest == '.' {
+			return true
+		}
+		if fr == 1 && dr == 2 && dc == 0 && dest == '.' && b.grid[fr+1][fc] == '.' {
+			return true
+		}
+		if dr == 1 && (dc == -1 || dc == 1) && dest != '.' && color(dest) == 1 {
+			return true
+		}
+	case 'R', 'r':
+		if dr == 0 || dc == 0 {
+			if b.clearPath(fr, fc, tr, tc) {
+				return true
+			}
+		}
+	case 'B', 'b':
+		if abs(dr) == abs(dc) {
+			if b.clearPath(fr, fc, tr, tc) {
+				return true
+			}
+		}
+	case 'Q', 'q':
+		if dr == 0 || dc == 0 || abs(dr) == abs(dc) {
+			if b.clearPath(fr, fc, tr, tc) {
+				return true
+			}
+		}
+	case 'N', 'n':
+		if (abs(dr) == 2 && abs(dc) == 1) || (abs(dr) == 1 && abs(dc) == 2) {
+			return true
+		}
+	case 'K', 'k':
+		if abs(dr) <= 1 && abs(dc) <= 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
 func (b *Board) Move(from, to string) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -54,6 +158,9 @@ func (b *Board) Move(from, to string) bool {
 	}
 	piece := b.grid[fr][fc]
 	if piece == '.' {
+		return false
+	}
+	if !b.validMove(fr, fc, tr, tc, piece) {
 		return false
 	}
 	b.grid[tr][tc] = piece


### PR DESCRIPTION
## Summary
- show chess pieces using Unicode symbols
- allow dragging pieces to another square
- validate moves on the Go server so illegal moves fail
- minor styling for draggable pieces

## Testing
- `npx prettier -w client/app.js client/index.html`
- `cd server && go build . && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_6852886d2ea48332b73cefc389117f31