### PR TITLE
Fix panic in Board.Reset

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -69,8 +69,10 @@ func sign(x int) int {
 func (b *Board) Reset() {
 	nb := NewBoard()
 	b.mu.Lock()
-	defer b.mu.Unlock()
-	*b = *nb
+	b.grid = nb.grid
+	b.turn = nb.turn
+	b.gameOver = nb.gameOver
+	b.mu.Unlock()
 }
 
 func (b *Board) clearPath(fr, fc, tr, tc int) bool {


### PR DESCRIPTION
## Summary
- protect board mutex when resetting state

## Testing
- `go run .` (backend starts)
- `curl -v http://localhost:8080/board`

------
https://chatgpt.com/codex/tasks/task_e_68528fdc38808332a88250cbcfd8fe71